### PR TITLE
Generate dimension-based SKU for custom wallpaper calculator

### DIFF
--- a/assets/custom-wallpaper.js
+++ b/assets/custom-wallpaper.js
@@ -8,6 +8,8 @@
   const propArea = document.querySelector('[data-wallpaper-prop-area]');
   const propSku = document.querySelector('[data-wallpaper-prop-sku]');
   const qtyInput = document.querySelector('[data-wallpaper-quantity]');
+  const formEl = document.getElementById('wallpaper-form');
+  const baseSku = (formEl?.dataset.productSku || '').slice(0, 7);
 
   const currencyFormatter = new Intl.NumberFormat('de-DE', {
     style: 'currency',
@@ -24,7 +26,9 @@
     propWidth.value = `${width.toFixed(2)}m`;
     propHeight.value = `${height.toFixed(2)}m`;
     propArea.value = `${area.toFixed(2)}m²`;
-    propSku.value = `CW-${width.toFixed(2)}x${height.toFixed(2)}`;
+    const widthCm = Math.round(width * 100);
+    const heightCm = Math.round(height * 100);
+    propSku.value = `${baseSku}_${heightCm}_${widthCm}`;
 
     if (qtyInput) {
       qtyInput.value = Math.max(1, Math.round(area * 100));

--- a/sections/custom-wallpaper.liquid
+++ b/sections/custom-wallpaper.liquid
@@ -19,7 +19,7 @@
     </div>
   </div>
 
-  <form id="wallpaper-form" method="post" action="/cart/add">
+  <form id="wallpaper-form" method="post" action="/cart/add" data-product-sku="{{ product.selected_or_first_available_variant.sku | escape }}">
     <input type="hidden" name="id" value="{{ product.selected_or_first_available_variant.id }}" />
     <input type="hidden" name="quantity" value="1" data-wallpaper-quantity />
     <input type="hidden" name="properties[Breite]" data-wallpaper-prop-width />


### PR DESCRIPTION
## Summary
- expose original variant SKU on custom wallpaper form
- build line item SKU using base SKU plus height/width in cm

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68a3379773b483209485b3a45f280dfa