### PR TITLE
Show slope hints during selection

### DIFF
--- a/assets/wall-assistant.js
+++ b/assets/wall-assistant.js
@@ -111,19 +111,21 @@
     }
 
     function updateSlopes() {
-      if (!enableSlopes) {
-        SL && SL.classList.add('ghost');
-        SR && SR.classList.add('ghost');
-        return;
-      }
-      const mode = state.slopes || 'none';
-      toggleSlope(SL, mode === 'left' || mode === 'both');
-      toggleSlope(SR, mode === 'right' || mode === 'both');
+      const step = currentStep();
+      const mode = enableSlopes ? state.slopes || 'none' : 'none';
+      const showGhosts = enableSlopes && step === 'slopes';
+      toggleSlope(SL, mode === 'left' || mode === 'both', showGhosts);
+      toggleSlope(SR, mode === 'right' || mode === 'both', showGhosts);
     }
-    function toggleSlope(el, active) {
+    function toggleSlope(el, active, showGhosts) {
       if (!el) return;
       el.classList.toggle('active', !!active);
-      el.classList.toggle('ghost', !active);
+      el.classList.toggle('ghost', !active && showGhosts);
+      if (active || (!active && showGhosts)) {
+        el.removeAttribute('hidden');
+      } else {
+        el.setAttribute('hidden', '');
+      }
     }
 
     function showDimensions(activeStep) {

--- a/sections/wall-assistant.liquid
+++ b/sections/wall-assistant.liquid
@@ -32,8 +32,8 @@
             <line data-el="hl-height" class="hl" x1="40" y1="40"  x2="40"  y2="240"></line>
 
             <!-- Dachschrägen -->
-            <polyline data-el="slope-left"  class="slope ghost" points="40,80 80,40"></polyline>
-            <polyline data-el="slope-right" class="slope ghost" points="320,40 360,80"></polyline>
+            <polyline data-el="slope-left"  class="slope" points="40,80 80,40" hidden></polyline>
+            <polyline data-el="slope-right" class="slope" points="320,40 360,80" hidden></polyline>
 
             <!-- Bemaßung -->
             <line data-el="dim-w" class="dim" x1="40" y1="252" x2="360" y2="252" marker-start="url(#wa-{{ section.id }}-arrow)" marker-end="url(#wa-{{ section.id }}-arrow)"></line>
@@ -152,8 +152,8 @@
       display: block;
     }
     .sketch-frame {
-      stroke: var(--color-foreground, #555);
-      stroke-width: 4;
+      stroke: #888;
+      stroke-width: 2;
       fill: none;
     }
     .sketch-fill {


### PR DESCRIPTION
## Summary
- Show dashed slope guides only while choosing roof slopes
- Use a thin, darker stroke for the wall outline

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a3374313788320a8155e653cff1f88