### PR TITLE
Split slope measurements into dedicated steps

### DIFF
--- a/assets/wall-assistant.js
+++ b/assets/wall-assistant.js
@@ -50,7 +50,17 @@
 
     let steps = ['intro'];
     if (enableSlopes) steps.push('slopes');
-    steps = steps.concat(['width', 'height', 'slope-left', 'slope-right', 'summary']);
+    steps = steps.concat([
+      'width',
+      'height',
+      'slope-left-peak',
+      'slope-left-offset',
+      'slope-left-start',
+      'slope-right-peak',
+      'slope-right-offset',
+      'slope-right-start',
+      'summary',
+    ]);
 
     let state = load() || {
       v: 1,
@@ -164,8 +174,8 @@
       let hl = 'intro';
       if (step === 'width') hl = 'width';
       else if (step === 'height') hl = 'height';
-      else if (step === 'slope-left') hl = 'slope-left';
-      else if (step === 'slope-right') hl = 'slope-right';
+      else if (step.startsWith('slope-left')) hl = 'slope-left';
+      else if (step.startsWith('slope-right')) hl = 'slope-right';
       sketch.setAttribute('data-highlight', hl);
       showDimensions(step);
       updateSlopes();
@@ -174,19 +184,19 @@
 
     function stepApplicable(name) {
       if (name === 'slopes') return enableSlopes;
-      if (name === 'slope-left') return state.slopes === 'left' || state.slopes === 'both';
-      if (name === 'slope-right') return state.slopes === 'right' || state.slopes === 'both';
+      if (name.startsWith('slope-left')) return state.slopes === 'left' || state.slopes === 'both';
+      if (name.startsWith('slope-right')) return state.slopes === 'right' || state.slopes === 'both';
       return true;
     }
 
     function updateSlopeGuides() {
       const step = currentStep();
-      toggleShow(SLH, step === 'slope-left');
-      toggleShow(SLO, step === 'slope-left');
-      toggleShow(SLS, step === 'slope-left');
-      toggleShow(SRH, step === 'slope-right');
-      toggleShow(SRO, step === 'slope-right');
-      toggleShow(SRS, step === 'slope-right');
+      toggleShow(SLH, step === 'slope-left-peak');
+      toggleShow(SLO, step === 'slope-left-offset');
+      toggleShow(SLS, step === 'slope-left-start');
+      toggleShow(SRH, step === 'slope-right-peak');
+      toggleShow(SRO, step === 'slope-right-offset');
+      toggleShow(SRS, step === 'slope-right-start');
     }
 
     function updateSlopes() {

--- a/sections/wall-assistant.liquid
+++ b/sections/wall-assistant.liquid
@@ -76,7 +76,6 @@
 
         <form class="assistant" data-step="width" hidden>
           <div class="field">
-            <label class="field__label" for="wall-width-{{ section.id }}">Breite der Wand</label>
             <input
               id="wall-width-{{ section.id }}"
               data-el="input-width"
@@ -88,6 +87,7 @@
               placeholder="z. B. 400"
               aria-describedby="unit-w-{{ section.id }}"
             >
+            <label class="field__label" for="wall-width-{{ section.id }}">Breite der Wand</label>
           </div>
           <div id="unit-w-{{ section.id }}" class="text-subdued">cm</div>
           <div class="assistant__nav">
@@ -98,7 +98,6 @@
 
         <form class="assistant" data-step="height" hidden>
           <div class="field">
-            <label class="field__label" for="wall-height-{{ section.id }}">Höhe der Wand</label>
             <input
               id="wall-height-{{ section.id }}"
               data-el="input-height"
@@ -110,6 +109,7 @@
               placeholder="z. B. 240"
               aria-describedby="unit-h-{{ section.id }}"
             >
+            <label class="field__label" for="wall-height-{{ section.id }}">Höhe der Wand</label>
           </div>
           <div id="unit-h-{{ section.id }}" class="text-subdued">cm</div>
           <div class="assistant__nav">
@@ -118,18 +118,10 @@
           </div>
         </form>
 
-        <form class="assistant" data-step="slope-left" hidden>
+        <form class="assistant" data-step="slope-left-peak" hidden>
           <div class="field">
-            <label class="field__label" for="slope-left-peak-{{ section.id }}">Höchster Punkt (Boden bis Ecke)</label>
             <input id="slope-left-peak-{{ section.id }}" data-el="input-left-peak" class="field__input" inputmode="decimal" pattern="[0-9]+([\\.,][0-9]+)?" placeholder="z. B. 250">
-          </div>
-          <div class="field">
-            <label class="field__label" for="slope-left-offset-{{ section.id }}">Abstand zur rechten Wand</label>
-            <input id="slope-left-offset-{{ section.id }}" data-el="input-left-offset" class="field__input" inputmode="decimal" pattern="[0-9]+([\\.,][0-9]+)?" placeholder="z. B. 120">
-          </div>
-          <div class="field">
-            <label class="field__label" for="slope-left-start-{{ section.id }}">Höhe, an der die Schräge beginnt</label>
-            <input id="slope-left-start-{{ section.id }}" data-el="input-left-start" class="field__input" inputmode="decimal" pattern="[0-9]+([\\.,][0-9]+)?" placeholder="z. B. 90">
+            <label class="field__label" for="slope-left-peak-{{ section.id }}">Höchster Punkt (Boden bis Ecke)</label>
           </div>
           <div class="assistant__nav">
             <button type="button" class="button button--secondary" data-prev>Zurück</button>
@@ -137,18 +129,54 @@
           </div>
         </form>
 
-        <form class="assistant" data-step="slope-right" hidden>
+        <form class="assistant" data-step="slope-left-offset" hidden>
           <div class="field">
-            <label class="field__label" for="slope-right-peak-{{ section.id }}">Höchster Punkt (Boden bis Ecke)</label>
+            <input id="slope-left-offset-{{ section.id }}" data-el="input-left-offset" class="field__input" inputmode="decimal" pattern="[0-9]+([\\.,][0-9]+)?" placeholder="z. B. 120">
+            <label class="field__label" for="slope-left-offset-{{ section.id }}">Abstand zur rechten Wand</label>
+          </div>
+          <div class="assistant__nav">
+            <button type="button" class="button button--secondary" data-prev>Zurück</button>
+            <button type="button" class="button button--primary" data-next>Weiter</button>
+          </div>
+        </form>
+
+        <form class="assistant" data-step="slope-left-start" hidden>
+          <div class="field">
+            <input id="slope-left-start-{{ section.id }}" data-el="input-left-start" class="field__input" inputmode="decimal" pattern="[0-9]+([\\.,][0-9]+)?" placeholder="z. B. 90">
+            <label class="field__label" for="slope-left-start-{{ section.id }}">Höhe, an der die Schräge beginnt</label>
+          </div>
+          <div class="assistant__nav">
+            <button type="button" class="button button--secondary" data-prev>Zurück</button>
+            <button type="button" class="button button--primary" data-next>Weiter</button>
+          </div>
+        </form>
+
+        <form class="assistant" data-step="slope-right-peak" hidden>
+          <div class="field">
             <input id="slope-right-peak-{{ section.id }}" data-el="input-right-peak" class="field__input" inputmode="decimal" pattern="[0-9]+([\\.,][0-9]+)?" placeholder="z. B. 250">
+            <label class="field__label" for="slope-right-peak-{{ section.id }}">Höchster Punkt (Boden bis Ecke)</label>
           </div>
+          <div class="assistant__nav">
+            <button type="button" class="button button--secondary" data-prev>Zurück</button>
+            <button type="button" class="button button--primary" data-next>Weiter</button>
+          </div>
+        </form>
+
+        <form class="assistant" data-step="slope-right-offset" hidden>
           <div class="field">
-            <label class="field__label" for="slope-right-offset-{{ section.id }}">Abstand zur linken Wand</label>
             <input id="slope-right-offset-{{ section.id }}" data-el="input-right-offset" class="field__input" inputmode="decimal" pattern="[0-9]+([\\.,][0-9]+)?" placeholder="z. B. 120">
+            <label class="field__label" for="slope-right-offset-{{ section.id }}">Abstand zur linken Wand</label>
           </div>
+          <div class="assistant__nav">
+            <button type="button" class="button button--secondary" data-prev>Zurück</button>
+            <button type="button" class="button button--primary" data-next>Weiter</button>
+          </div>
+        </form>
+
+        <form class="assistant" data-step="slope-right-start" hidden>
           <div class="field">
-            <label class="field__label" for="slope-right-start-{{ section.id }}">Höhe, an der die Schräge beginnt</label>
             <input id="slope-right-start-{{ section.id }}" data-el="input-right-start" class="field__input" inputmode="decimal" pattern="[0-9]+([\\.,][0-9]+)?" placeholder="z. B. 90">
+            <label class="field__label" for="slope-right-start-{{ section.id }}">Höhe, an der die Schräge beginnt</label>
           </div>
           <div class="assistant__nav">
             <button type="button" class="button button--secondary" data-prev>Zurück</button>


### PR DESCRIPTION
## Summary
- break roof slope inputs into individual steps
- highlight matching measurement guides while entering values
- ensure field labels are visible

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a46bb4eb748320aa5ebf0149a77ad3